### PR TITLE
The KVStore constructor called the old Vault implementation constructor

### DIFF
--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -23,7 +23,7 @@ func NewKeyValueStore(config configuration.KeyValueStoreConfiguration, tracer tr
 			"key":    config.Vault.ClientTlsKey,
 			"caCert": config.Vault.ServerTlsCert,
 		}
-		vaultKVclient, vaultKVclientError := NewVaultKeyValueStore(config.Vault.Url, config.Vault.Token, params, tracer)
+		vaultKVclient, vaultKVclientError := NewVaultKeyValueStore(config.Vault.Url, config.Vault.Token, params)
 		if vaultKVclientError != nil {
 			return nil, vaultKVclientError
 		}


### PR DESCRIPTION
Bad by me! Caught when trying to upgrade lamia to use the new library. (it doesn't use it, but wouldn't build!)